### PR TITLE
Added lowercasing of non-keyword items

### DIFF
--- a/lib/SQL/Beautify.pm
+++ b/lib/SQL/Beautify.pm
@@ -64,6 +64,7 @@ sub new {
 	$self->{keywords} = []   unless defined($self->{keywords});
 	$self->{rules}    = {}   unless defined($self->{rules});
 	$self->{uc_keywords} = 0 unless defined $self->{uc_keywords};
+	$self->{lc_names} = 0    unless defined $self->{lc_names};
 
 	push @{$self->{keywords}}, KEYWORDS;
 
@@ -231,6 +232,10 @@ sub _add_token {
 	# uppercase keywords
 	$token = uc $token
 		if $self->_is_keyword($token) and $self->{uc_keywords};
+
+	# lowercase name	
+	$token = lc $token 
+		if $self->{lc_names} and !$self->_is_keyword( $token ) and	!$self->_is_constant( $token );
 
 	$self->{_output} .= $token;
 
@@ -431,6 +436,11 @@ color escape sequences.
 =item B<uc_keywords> => 1|0
 
 When true (1) all SQL keywords will be uppercased in output.  Default is false (0).
+
+=item B<lc_names> => 1|0
+
+When true (1) all SQL names (ie not keywords or constants) will be lowercased in output.
+Default is false (0).
 
 =back
 

--- a/t/case_handling.t
+++ b/t/case_handling.t
@@ -1,0 +1,30 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use SQL::Beautify;
+
+my $sql = new SQL::Beautify( spaces => 2, uc_keywords => 1, lc_names => 1 );
+my $query;
+my $beauty;
+
+ok( $sql, 'got instance' );
+
+while ( my $in = <DATA> ) {
+    my $result   = eval $in;
+    my $deformat = $result;
+    $deformat =~ tr/\r\n\t / /s;
+    $sql->query( uc($deformat) );
+    is( $result, $sql->beautify, 'Test convert from upper case' );
+    $sql->query( lc($deformat) );
+    is( $result, $sql->beautify, 'Test convert from lower case' );
+}
+
+done_testing;
+
+__DATA__
+"SELECT\n  *\nFROM\n  foo,\n  bar,\n  baz\nWHERE\n  foo.id = bar.id\n  AND\n  bar.id = baz.id\n"
+"SELECT\n  *\nFROM\n  foo,\n  bar,\n  baz\nWHERE\n  foo.id = bar.id\n  AND\n  bar.id = baz.id\n"
+"SELECT\n  foo.id,\n  bar.name\nFROM\n  foo,\n  bar,\n  baz\nWHERE\n  foo.id = bar.id\n  AND\n  bar.id = baz.id\n  OR\n  bar.id != foo.id\n"


### PR DESCRIPTION
Hi.  

This commit adds a lc_names option which transforms names (ie not keywords, not constants) to lower case.

I did this a while back because our outsourced devs appear to randomly flip case all over the show when writing any SQL - so I hit all their SQL hard before committing it to my repo.

Theres a basic test of general case mangling included.

I suspect there may be some very minor clashing with szabgab's work.  If I get the chance I will pull his line and merge it too, but last time I touched this code I ended up leaving it for a while and then playing catch up with your changes...

Cheers
   Nigel.

[nigelm@cpan.org]
