### PR TITLE
Force new line after a line comment

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for SQL-Beautify
 
+0.05    2022-03-09
+        * Force new linr after a line comment
+
 0.04	2011-08-07
 		* Support for adding own keywords.
 		* Support for custom rules
@@ -15,7 +18,7 @@ Revision history for SQL-Beautify
 0.02	2009-03-29
 		* Fix in documentation.
 		* Line break before ORDER BY and GROUP BY.
-		
+
 
 0.01    2009-02-22
         First version, released on an unsuspecting world.

--- a/lib/SQL/Beautify.pm
+++ b/lib/SQL/Beautify.pm
@@ -115,6 +115,11 @@ sub beautify {
 			$self->_process_rule($rule, $token);
 		}
 
+		elsif($token =~ /^--$/i) {
+			$self->_add_token($token);
+			$self->_new_line;
+		}
+
 		elsif($token eq '(') {
 			$self->_add_token($token);
 			$self->_new_line;
@@ -233,8 +238,8 @@ sub _add_token {
 	$token = uc $token
 		if $self->_is_keyword($token) and $self->{uc_keywords};
 
-	# lowercase name	
-	$token = lc $token 
+	# lowercase name
+	$token = lc $token
 		if $self->{lc_names} and !$self->_is_keyword( $token ) and	!$self->_is_constant( $token );
 
 	$self->{_output} .= $token;

--- a/t/line_comment.t
+++ b/t/line_comment.t
@@ -1,0 +1,30 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 4;
+use SQL::Beautify;
+
+my $sql = new SQL::Beautify(spaces => 2);
+my $query;
+my $beauty;
+
+ok($sql, 'got instance');
+
+# Test plain text formatting.
+$query = <DATA>;
+$beauty = <DATA>;
+
+$query = eval $query;
+$beauty = eval $beauty;
+
+ok($sql->query($query) eq $query, 'query set');
+ok($sql->query eq $query, 'query get');
+
+ok($sql->beautify eq $beauty, 'beautified');
+
+
+__DATA__
+"SELECT * FROM foo, bar, baz WHERE foo.id = bar.id -- AND bar.id = baz.id\nORDER BY bar"
+"SELECT\n  *\nFROM\n  foo,\n  bar,\n  baz\nWHERE\n  foo.id = bar.id -- AND bar.id = baz.id\nORDER BY\n  bar\n"


### PR DESCRIPTION
Force a new line after a comment to avoid commenting valid statements